### PR TITLE
jscs won't stop gulp watch on errors

### DIFF
--- a/gulp/tasks/tests-jscs.js
+++ b/gulp/tasks/tests-jscs.js
@@ -18,8 +18,15 @@ module.exports = function( gulp, options ) {
 
   return function() {
 
-    return gulp.src( options.src )
+    var stream = gulp.src( options.src )
       .pipe(jscs());
+
+    stream.on('error', function(error) {
+
+      console.log(error.message);
+    });
+
+    return stream;
 
   };
 


### PR DESCRIPTION
JSCS was stopping gulp watch when it found an error. 
adding a listener prevents that from happening.